### PR TITLE
Update image tag to v0.0.2

### DIFF
--- a/kubernetes/kustomization.yaml
+++ b/kubernetes/kustomization.yaml
@@ -15,7 +15,7 @@ resources:
 # Image customization - override image tags
 images:
 - name: raelga/ff5-dreamroute
-  newTag: main
+  newTag: v0.0.2
 
 # Add prefix to all resource names to avoid conflicts
 namePrefix: dreamroute-


### PR DESCRIPTION
### ⚠️ Merging this PR will trigger a deployment to the Kubernetes cluster using ArgoCD. ⚠️ 

## Summary
Automated PR to update the Kubernetes kustomization file with the new image tag from the latest release.

## Changes
- Updated `kubernetes/kustomization.yaml` image tag to ``
- This corresponds to the Docker image: `raelga/ff5-dreamroute:v0.0.2`

## Release Workflow
- Triggered by release workflow run: https://github.com/raelga/ff5-DreamRoute/actions/runs/18186989068
- Release tag: `v0.0.2`